### PR TITLE
Use upstream manifest

### DIFF
--- a/io.gitlab.windstille.Windstille-0_2.json
+++ b/io.gitlab.windstille.Windstille-0_2.json
@@ -13,6 +13,9 @@
         "--socket=x11",
         "--socket=pulseaudio"
     ],
+    "cleanup": [
+        "/lib/libguile-3.0.so.1.2.0-gdb.scm"
+    ],
     "modules": [
         "shared-modules/libatomic_ops/libatomic_ops-7.6.10.json",
         "shared-modules/bdwgc/bdwgc-7.6.6.json",
@@ -26,7 +29,7 @@
         "shared-modules/swig/swig-3.0.12.json",
         {
             "name": "windstille-0.2",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "git",

--- a/io.gitlab.windstille.Windstille-0_2.json
+++ b/io.gitlab.windstille.Windstille-0_2.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.gitlab.windstille.Windstille-0_2",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "windstille-0.2",
     "rename-icon": "windstille-0.2",
@@ -14,36 +14,24 @@
         "--socket=pulseaudio"
     ],
     "modules": [
-        "shared-modules/guile/guile-1.8.8.json",
-        "shared-modules/scons/scons-2.5.1.json",
+        "shared-modules/libatomic_ops/libatomic_ops-7.6.10.json",
+        "shared-modules/bdwgc/bdwgc-7.6.6.json",
+        "shared-modules/unistring/unistring-0.9.10.json",
+        "shared-modules/guile/guile-3.0.4.json",
+        "shared-modules/scons/scons-4.json",
         "shared-modules/xmu/libxmu-1.1.2.json",
-        "shared-modules/glu/glu-9.0.0.json",
+        "shared-modules/glu/glu-9.json",
         "shared-modules/SDL/SDL-1.2.15.json",
         "shared-modules/clanlib/clanlib-1.0.json",
         "shared-modules/swig/swig-3.0.12.json",
         {
             "name": "windstille-0.2",
-            "buildsystem": "simple",
-            "build-commands": [
-                "scons -u",
-                "cp -v windstille /app/bin/windstille-0.2",
-                "cp -vR data /app/share/windstille-0.2",
-                "mkdir -p /app/share/metainfo",
-                "cp -vR windstille-0.2.appdata.xml /app/share/metainfo",
-                "mkdir -p /app/share/icons/hicolor/scalable/apps",
-                "cp -vR windstille-0.2.svg /app/share/icons/hicolor/scalable/apps",
-                "mkdir -p /app/share/applications",
-                "cp -vR windstille-0.2.desktop /app/share/applications"
-            ],
+            "buildsystem": "cmake",
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.com/windstille/windstille.git",
-                    "commit": "175cac06edc5e8281da993b5119bf100e89c4e42"
-                },
-                {
-                    "type": "patch",
-                    "path": "windstille-0.2-datadir.patch"
+                    "url": "https://gitlab.com/Windstille/windstille.git",
+                    "commit": "063abaa68ea11afae1dbf33dedea58136c25e6ec"
                 }
             ]
         }


### PR DESCRIPTION
from : https://gitlab.com/Windstille/windstille/-/blob/windstille-0.2.x/io.gitlab.windstille.Windstille-0_2.json

It doesn't build because the shared-modules want lz archives which can't be extracted.
After changing that, it results in when trying to start the game :

```
ldconfig: /app/lib/libguile-3.0.so.1.2.0-gdb.scm is not an ELF file - it has the wrong magic bytes at the start.

Created /var/home/DaSH/.windstille
Loading Guile Code... done
Detected 0 joysticks
InputManager::init(/app/share/windstille-0.2/controller/keyboard.scm)
;;; note: auto-compilation is enabled, set GUILE_AUTO_COMPILE=0
;;;       or pass the --no-auto-compile argument to disable.
;;; compiling /app/share/windstille-0.2/helper.scm
;;; helper.scm:15:2: warning: possibly unbound variable `scm-repl-prompt'
;;; helper.scm:16:4: warning: possibly unbound variable `set-repl-prompt!'
;;; helper.scm:19:13: warning: possibly unbound variable `top-repl'
;;; helper.scm:24:4: warning: possibly unbound variable `set-repl-prompt!'
;;; compiled /var/home/DaSH/.var/app/io.gitlab.windstille.Windstille-0_2/cache/guile/ccache/3.0-LE-8-4.3/app/share/windstille-0.2/helper.scm.go
;;; compiling /app/share/windstille-0.2/gui.scm
;;; compiled /var/home/DaSH/.var/app/io.gitlab.windstille.Windstille-0_2/cache/guile/ccache/3.0-LE-8-4.3/app/share/windstille-0.2/gui.scm.go
/usr/include/c++/10.2.0/bits/stl_vector.h:1063: (null): Assertion '__builtin_expect(__n < this->size(), true)' failed.```